### PR TITLE
build_*_kernel_image.sh: parametrize linux build dir

### DIFF
--- a/linux/build_nios2_kernel_image.sh
+++ b/linux/build_nios2_kernel_image.sh
@@ -5,8 +5,9 @@ DEFCONFIG=adi_nios2_defconfig
 DTDEFAULT=a10gx_adrv9371.dts
 
 CROSS_COMPILE="$1"
-BRANCH="${2:-altera_4.9}"
-DTFILE="$3"
+LINUX_DIR=${2:-linux-adi}
+BRANCH="${3:-altera_4.9}"
+DTFILE="$4"
 
 ARCH=nios2
 
@@ -17,14 +18,15 @@ NUM_JOBS=${NUM_JOBS:-4}
 # if CROSS_COMPILE hasn't been specified, fail here
 # we don't have a good alternative to download at the moment
 [ -n "$CROSS_COMPILE" ] || {
-	echo "usage: <path-to-nios2-toolchain> [DTFILE]"
+	echo "usage: <path-to-nios2-toolchain> [linux-dir] [branch] [DTFILE]"
+	echo "Please specify a Nios 2 toolchain prefix."
 	exit 1
 }
 
 # Get ADI Linux if not downloaded
 # We won't do any `git pull` to update the tree, users can choose to do that manually
-[ -d linux-adi ] || \
-	git clone https://github.com/analogdevicesinc/linux.git linux-adi
+[ -d "$LINUX_DIR" ] || \
+	git clone https://github.com/analogdevicesinc/linux.git "$LINUX_DIR"
 
 if [ -z "$DTFILE" ] ; then
 	echo
@@ -35,7 +37,7 @@ fi
 export ARCH
 export CROSS_COMPILE
 
-pushd linux-adi
+pushd "$LINUX_DIR"
 
 git checkout "$BRANCH"
 
@@ -51,7 +53,7 @@ make -j$NUM_JOBS $IMG_NAME
 
 popd 1> /dev/null
 
-cp -f linux-adi/arch/$ARCH/boot/$IMG_NAME .
+cp -f $LINUX_DIR/arch/$ARCH/boot/$IMG_NAME .
 
 echo
 echo "Exported files: $IMG_NAME"

--- a/linux/build_zynq_kernel_image.sh
+++ b/linux/build_zynq_kernel_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Usage: build_zynq_kernel_image.sh [zynq|zynqmp] [dt_file] [path_cross_toolchain]
+# Usage: build_zynq_kernel_image.sh [zynq|zynqmp] [kernel_dir] [dt_file] [path_cross_toolchain]
 #  If no 'zynq' or 'zynqmp' is specified, 'zynq' is the default value
 #  If no dt_file is specified, the default is `zynq-zc702-adv7511-ad9361-fmcomms2-3.dtb`
 #  If no CROSS_COMPILE specified, a GCC toolchain will be downloaded
@@ -16,8 +16,9 @@ set -e
 #
 
 ZYNQ_TYPE="$1"
-DTFILE="$2"
-CROSS_COMPILE="$3"
+LINUX_DIR="${2:-linux-adi}"
+DTFILE="$3"
+CROSS_COMPILE="$4"
 
 HOST=${HOST:-x86_64}
 
@@ -65,13 +66,13 @@ get_linaro_link() {
 
 # Get ADI Linux if not downloaded
 # We won't do any `git pull` to update the tree, users can choose to do that manually
-[ -d linux-adi ] || \
-	git clone https://github.com/analogdevicesinc/linux.git linux-adi
+[ -d "$LINUX_DIR" ] || \
+	git clone https://github.com/analogdevicesinc/linux.git "$LINUX_DIR"
 
 export ARCH
 export CROSS_COMPILE
 
-pushd linux-adi
+pushd "$LINUX_DIR"
 
 make $DEFCONFIG
 
@@ -87,8 +88,8 @@ make $DTFILE
 
 popd 1> /dev/null
 
-cp -f linux-adi/arch/$ARCH/boot/$IMG_NAME .
-cp -f linux-adi/arch/$ARCH/boot/dts/$DTFILE .
+cp -f $LINUX_DIR/arch/$ARCH/boot/$IMG_NAME .
+cp -f $LINUX_DIR/arch/$ARCH/boot/dts/$DTFILE .
 
 echo "Exported files: $IMG_NAME, $DTFILE"
 


### PR DESCRIPTION
If there's already a cloned local repo for the kernel
this allows the scripts to use that instead.

Otherwise the scripts will clone a `linux-adi` one.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>