### PR TITLE
build_zynqmp_boot_bin.sh: Update Vitis version extraction command

### DIFF
--- a/zynqmp_boot_bin/build_zynqmp_boot_bin.sh
+++ b/zynqmp_boot_bin/build_zynqmp_boot_bin.sh
@@ -46,9 +46,9 @@ mkdir -p $BUILD_DIR
 # 2023.1 use c7385e021c0b95a025f2c78384d57224e0120401
 # 2023.2 use 04013814718e870261f27256216cd7da3eda6a5d
 
-tool_version=$(vitis -version | sed -n '3p' | cut -d' ' -f 3)
-if [ -z "$tool_version" ] ; then
-	echo "Could not determine Vivado version"
+tool_version=$(vitis -v | grep -o "Vitis v20[1-9][0-9]\.[0-9] (64-bit)" | grep -o "v20[1-9][0-9]\.[0-9]")
+if [[ "$tool_version" != "v20"[1-9][0-9]"."[0-9] ]] ; then
+	echo "Could not determine Vitis version"
 	exit 1
 fi
 atf_version=xilinx-$tool_version


### PR DESCRIPTION
Updated the tool_version check, to check for v20[1-9][0-9].[0-9] version format (as it is specified like v2023.2, for example, when running "vitis -version" or "vitis -v")