### PR TITLE
ci: add CODEOWNERS and document innersource sync flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/utils/cloudsmith_utils/ @SRaus @bancsorin10 @liviutomoiaga

--- a/.github/workflows/check-sync-conflicts.yml
+++ b/.github/workflows/check-sync-conflicts.yml
@@ -1,0 +1,43 @@
+name: Check sync conflicts
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'utils/cloudsmith_utils/**'
+
+jobs:
+  check-conflicts:
+    # Only run on sync PRs from the bot
+    if: github.head_ref == 'sync-cloudsmith-helper'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for local changes that would be overwritten
+        run: |
+          # Get the merge base (last common commit)
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+
+          # Check if main has commits touching synced files since merge base
+          MAIN_CHANGES=$(git log --oneline "$MERGE_BASE..origin/main" -- utils/cloudsmith_utils/)
+
+          if [ -n "$MAIN_CHANGES" ]; then
+            echo "::error::Local changes detected in utils/cloudsmith_utils/ that would be overwritten by this sync."
+            echo ""
+            echo "Commits on main since last sync:"
+            echo "$MAIN_CHANGES"
+            echo ""
+            echo "Please cherry-pick these changes to innersource first, or resolve manually."
+            exit 1
+          fi
+
+          echo "No local changes detected. Safe to merge."

--- a/utils/cloudsmith_utils/README.md
+++ b/utils/cloudsmith_utils/README.md
@@ -1,0 +1,30 @@
+# Cloudsmith Utils
+
+This directory is synced from an internal (innersource) repository via GitHub Actions.
+
+## Contributing
+
+Open source contributors are welcome to submit PRs to this repository.
+
+### Contribution flow
+
+1. Submit your PR to this repository
+2. We review and merge your changes
+3. We cherry-pick the changes to the innersource repository
+4. The sync workflow runs and may create a PR:
+   - If the cherry-pick is identical, no sync PR is created
+   - If there are conflicts, the sync PR will require manual resolution
+
+### Sync protection
+
+A CI check runs on sync PRs to detect if local changes would be overwritten.
+If this repository has commits touching the synced files that haven't been
+cherry-picked to innersource yet, the check fails and blocks auto-merge.
+
+### For maintainers
+
+After merging an open source contribution, cherry-pick the changes to
+innersource promptly. If a sync PR fails the conflict check:
+
+1. Cherry-pick the missing changes to innersource, or
+2. Manually resolve the differences before merging


### PR DESCRIPTION
- Add .github/CODEOWNERS to assign devops team as reviewers for sync PRs
- Add CI workflow to block sync PRs that would overwrite local changes
- Add README documenting contribution flow and sync protection